### PR TITLE
Revert "Switch STATICFILES_STORAGE, to work around a bug with drf-yasg"

### DIFF
--- a/composed_configuration/_configuration.py
+++ b/composed_configuration/_configuration.py
@@ -72,6 +72,11 @@ class TestingBaseConfiguration(MinioStorageMixin, _BaseConfiguration):
 
     MINIO_STORAGE_MEDIA_BUCKET_NAME = 'test-django-storage'
 
+    # To generate static file URLs in testing (where DEBUG is False),
+    # CompressedManifestStaticFilesStorage requires collectstatic to be run,
+    # so use an alternative which does not require that
+    STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
+
     # Testing will set EMAIL_BACKEND to use the memory backend
 
 

--- a/composed_configuration/_static.py
+++ b/composed_configuration/_static.py
@@ -72,6 +72,4 @@ class WhitenoiseStaticFileMixin(StaticFileMixin):
             security_index + 1, 'whitenoise.middleware.WhiteNoiseMiddleware'
         )
 
-    # CompressedManifestStaticFilesStorage does not work properly with drf-
-    # https://github.com/axnsan12/drf-yasg/issues/761
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
+    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'


### PR DESCRIPTION
Reverts girder/django-composed-configuration#175

This can be applied when https://github.com/axnsan12/drf-yasg/issues/761 is fixed.