### PR TITLE
Remove default Forgot Password link from login form

### DIFF
--- a/composed_configuration/_allauth.py
+++ b/composed_configuration/_allauth.py
@@ -48,6 +48,10 @@ class AllauthMixin(ConfigMixin):
     # Require email verification, but this can be overridden
     ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 
+    # We override the login form to exclude the default forgot password link, because
+    # auth_style provides its own custom one.
+    ACCOUNT_FORMS = {"login": "composed_configuration._allauth_support.forms.LoginOverrideForm"}
+
     # Make Django and Allauth redirects consistent, but both may be overridden
     LOGIN_REDIRECT_URL = "/"
     ACCOUNT_LOGOUT_REDIRECT_URL = "/"

--- a/composed_configuration/_allauth_support/forms.py
+++ b/composed_configuration/_allauth_support/forms.py
@@ -1,0 +1,7 @@
+from allauth.account.forms import LoginForm
+
+
+class LoginOverrideForm(LoginForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["password"].help_text = None


### PR DESCRIPTION
`auth_style` provides its own custom Forgot Password link, so we remove the default to avoid having duplicate links.