### PR TITLE
Add Django 5.0 to officially supported Django versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Environment :: Web Environment",
   "Framework :: Django :: 4",
   "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.0",
   "Framework :: Django",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Closes kitware-resonant/cookiecutter-resonant#219 