### PR TITLE
Add `django-browser-reload` to debug tooling

### DIFF
--- a/composed_configuration/_debug.py
+++ b/composed_configuration/_debug.py
@@ -5,17 +5,20 @@ class DebugMixin(ConfigMixin):
     """
     Configure debug tooling.
 
-    This requires the `django-debug-toolbar` package to be installed.
+    This requires the `django-debug-toolbar` and `django-browser-reload`
+    packages to be installed.
     """
 
     @staticmethod
     def mutate_configuration(configuration: type[ComposedConfiguration]) -> None:
-        configuration.INSTALLED_APPS += ["debug_toolbar"]
+        configuration.INSTALLED_APPS += ["debug_toolbar", "django_browser_reload"]
 
         # Include Debug Toolbar middleware as early as possible in the list.
         # However, it must come after any other middleware that encodes the response’s content,
         # such as GZipMiddleware.
         configuration.MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
+
+        configuration.MIDDLEWARE.append("django_browser_reload.middleware.BrowserReloadMiddleware")
 
     DEBUG_TOOLBAR_CONFIG = {
         # The default size often is too small, causing an inability to view queries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ Repository = "https://github.com/kitware-resonant/django-composed-configuration"
 
 [project.optional-dependencies]
 dev = [
+  "django-browser-reload",
   "django-debug-toolbar",
   "django-minio-storage",
   "psycopg[binary]",


### PR DESCRIPTION
This adds [django-browser-reload](https://github.com/adamchainz/django-browser-reload) to the `DebugMixin`. 

Currently, the `DebugMixin` just enables `django-debug-toolbar`. I think `django-browser-reload` is also really helpful in a similar manner to `django-debug-toolbar`, and fits nicely in the `DebugMixin`. 

Similarly to `django-debug-toolbar`, this will also require a change to the `urls.py` file in the cookiecutter [here](https://github.com/girder/cookiecutter-girder-4/blob/master/%7B%7B%20cookiecutter.project_slug%20%7D%7D/%7B%7B%20cookiecutter.pkg_name%20%7D%7D/urls.py#L42-L44). I can make another PR there if needed, I just wanted to open this one first to see if there's any interest in making this change.